### PR TITLE
feat(blog): hover underline animation + page transitions

### DIFF
--- a/apps/blog/src/app/globals.css
+++ b/apps/blog/src/app/globals.css
@@ -60,43 +60,17 @@
   }
 }
 
-.prose :where(code):not(:where(pre *))::before,
-.prose :where(code):not(:where(pre *))::after {
-  content: none;
-}
+@layer base {
+  .prose :where(code):not(:where(pre *))::before,
+  .prose :where(code):not(:where(pre *))::after {
+    content: none;
+  }
 
-.prose :where(code):not(:where(pre *)) {
-  @apply bg-muted rounded px-1.5 py-0.5 text-[0.85em] font-normal;
-}
+  .prose :where(code):not(:where(pre *)) {
+    @apply bg-muted rounded px-1.5 py-0.5 text-[0.85em] font-normal;
+  }
 
-.prose pre {
-  @apply overflow-x-auto rounded-lg p-4 text-sm leading-relaxed;
-}
-
-.link-underline {
-  position: relative;
-  display: inline-block;
-}
-
-.link-underline::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  bottom: -1px;
-  height: 1px;
-  width: 100%;
-  background-color: currentColor;
-  transform: scaleX(0);
-  transform-origin: left;
-  transition: transform 0.3s ease;
-}
-
-.group:hover .link-underline::after {
-  transform: scaleX(1);
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .link-underline::after {
-    transition: none;
+  .prose pre {
+    @apply overflow-x-auto rounded-lg p-4 text-sm leading-relaxed;
   }
 }

--- a/apps/blog/src/app/globals.css
+++ b/apps/blog/src/app/globals.css
@@ -72,3 +72,31 @@
 .prose pre {
   @apply overflow-x-auto rounded-lg p-4 text-sm leading-relaxed;
 }
+
+.link-underline {
+  position: relative;
+  display: inline-block;
+}
+
+.link-underline::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -1px;
+  height: 1px;
+  width: 100%;
+  background-color: currentColor;
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.3s ease;
+}
+
+.group:hover .link-underline::after {
+  transform: scaleX(1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .link-underline::after {
+    transition: none;
+  }
+}

--- a/apps/blog/src/app/page.tsx
+++ b/apps/blog/src/app/page.tsx
@@ -27,10 +27,7 @@ export default async function BlogHome() {
       <ul className="border-y">
         {posts.map((post, index) => (
           <li key={post.slug} className={index > 0 ? "border-t" : undefined}>
-            <Link
-              href={`/posts/${post.slug}`}
-              className="group -mx-3 flex gap-4 rounded-xl px-3 py-4 transition-colors duration-200 hover:bg-muted/60"
-            >
+            <Link href={`/posts/${post.slug}`} className="group flex gap-4 py-4">
               <div className="relative h-[70px] w-[104px] flex-none overflow-hidden rounded-md border">
                 <Image
                   src={post.cover}
@@ -46,7 +43,7 @@ export default async function BlogHome() {
                     {post.title}
                     <span
                       aria-hidden
-                      className="bg-current absolute -bottom-px left-0 h-px w-0 transition-[width] duration-300 ease-out group-hover:w-full motion-reduce:transition-none"
+                      className="bg-current absolute -bottom-0.5 left-0 h-0.5 w-0 transition-[width] duration-300 ease-out group-hover:w-full motion-reduce:transition-none"
                     />
                   </span>
                 </h2>

--- a/apps/blog/src/app/page.tsx
+++ b/apps/blog/src/app/page.tsx
@@ -42,7 +42,7 @@ export default async function BlogHome() {
               </div>
               <div className="min-w-0 flex-1">
                 <h2 className="text-base font-medium leading-snug">
-                  {post.title}
+                  <span className="link-underline">{post.title}</span>
                 </h2>
                 <p className="text-muted-foreground mt-1 truncate text-[13px] leading-relaxed">
                   {post.description}

--- a/apps/blog/src/app/page.tsx
+++ b/apps/blog/src/app/page.tsx
@@ -24,21 +24,24 @@ export default async function BlogHome() {
         <p className="text-muted-foreground text-sm">권중운의 개발 노트 · 글 {posts.length}편</p>
       </header>
 
-      <ul className="border-b">
-        {posts.map((post) => (
-          <li key={post.slug}>
-            <Link href={`/posts/${post.slug}`} className="group flex gap-4 border-t py-4">
+      <ul className="border-y">
+        {posts.map((post, index) => (
+          <li key={post.slug} className={index > 0 ? "border-t" : undefined}>
+            <Link
+              href={`/posts/${post.slug}`}
+              className="group -mx-3 flex gap-4 rounded-xl px-3 py-4 transition-colors duration-200 hover:bg-muted/60"
+            >
               <div className="relative h-[70px] w-[104px] flex-none overflow-hidden rounded-md border">
                 <Image
                   src={post.cover}
                   alt=""
                   fill
                   sizes="104px"
-                  className="object-cover transition-transform duration-300 group-hover:scale-105"
+                  className="object-cover transition-transform duration-300 ease-out group-hover:scale-105"
                 />
               </div>
               <div className="min-w-0 flex-1">
-                <h2 className="text-base font-medium leading-snug group-hover:underline">
+                <h2 className="text-base font-medium leading-snug">
                   {post.title}
                 </h2>
                 <p className="text-muted-foreground mt-1 truncate text-[13px] leading-relaxed">

--- a/apps/blog/src/app/page.tsx
+++ b/apps/blog/src/app/page.tsx
@@ -42,7 +42,13 @@ export default async function BlogHome() {
               </div>
               <div className="min-w-0 flex-1">
                 <h2 className="text-base font-medium leading-snug">
-                  <span className="link-underline">{post.title}</span>
+                  <span className="relative inline-block">
+                    {post.title}
+                    <span
+                      aria-hidden
+                      className="bg-current absolute -bottom-px left-0 h-px w-0 transition-[width] duration-300 ease-out group-hover:w-full motion-reduce:transition-none"
+                    />
+                  </span>
                 </h2>
                 <p className="text-muted-foreground mt-1 truncate text-[13px] leading-relaxed">
                   {post.description}

--- a/apps/blog/src/app/template.tsx
+++ b/apps/blog/src/app/template.tsx
@@ -1,0 +1,7 @@
+export default function Template({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="animate-in fade-in-0 slide-in-from-bottom-2 duration-500 ease-out motion-reduce:animate-none">
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
Follow-up to #36. These blog list/navigation polish commits were pushed to
`feat/blog` **after** #36 was already squash-merged, so they didn't make it
onto `main`. This brings them over (cherry-picked).

- List title underline: animated left-to-right grow on hover (width 0 → full),
  2px thick, no row background. Built with Tailwind utilities so it survives
  the Tailwind v4 production build.
- Page transitions: `app/template.tsx` plays a subtle fade + slide-up on every
  navigation (into a post and back), respecting prefers-reduced-motion.
- Custom prose rules moved into `@layer base` so they're emitted in prod too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
